### PR TITLE
2024-02-08 - nat | enable production mode for server

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -5,7 +5,6 @@ config.each do |key, value|
   ENV[key] = value
 end
 
-
 require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,3 +1,14 @@
+# Load environment variables from separate file
+require 'yaml'
+config = YAML.safe_load(File.read(File.expand_path('./environment-variables.yml', __dir__)))
+config.each do |key, value|
+  ENV[key] = value
+end
+
+#   # Load the Rails application
+#   require File.expand_path('application', __dir__)
+
+
 require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'

--- a/config/application.rb
+++ b/config/application.rb
@@ -5,9 +5,6 @@ config.each do |key, value|
   ENV[key] = value
 end
 
-#   # Load the Rails application
-#   require File.expand_path('application', __dir__)
-
 
 require File.expand_path('../boot', __FILE__)
 

--- a/config/environment-variables.yml
+++ b/config/environment-variables.yml
@@ -1,0 +1,4 @@
+# Add environment variables to this file in the below format
+VAR1: 'value1'
+VAR2: 'value2'
+VAR3: 'value3'


### PR DESCRIPTION
NOTE: it may be required to run `RAILS_ENV=production bundle exec rake assets:precompile` to precompile assets before starting the server.

I added a section to the `config/application.rb` to load environment variables (including `RAILS_ENV` and `RACK_ENV`, which can be set to 'production') from the new `environment-variables.yml` file I made.

Then contents of `environment-variables.yml` is not available on this GitHub for security reasons.